### PR TITLE
Update header scroll initial state

### DIFF
--- a/src/components/header/index.jsx
+++ b/src/components/header/index.jsx
@@ -19,7 +19,7 @@ const query = graphql`
 `;
 
 const useWindowScroll = () => {
-  const [scrollY, setScrollY] = useState(0);
+  const [scrollY, setScrollY] = useState(window.scrollY);
 
   useEffect(() => {
     const handleScroll = () => setScrollY(window.scrollY);


### PR DESCRIPTION
This fixes the issue with the navbar background not being updated after a page refresh.

Example:
![issue with the navbar background](https://d.pr/i/5s1lMD+)